### PR TITLE
index: Update the installation command

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,10 +111,10 @@
         </ul>
         <div class="wide">
             <div class="curl">
-                <p class="code">$ sh -c "$(curl -fsSL https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh)"</p>
+                <p class="code">$ bash -c "$(curl -fsSL https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh)"</p>
             </div>
             <div class="wget">
-                <p class="code">$ sh -c "$(wget https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh -O -)"</p>
+                <p class="code">$ bash -c "$(wget https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh -O -)"</p>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -111,10 +111,10 @@
         </ul>
         <div class="wide">
             <div class="curl">
-                <p class="code">$ bash -c "$(curl -fsSL https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh)"</p>
+                <p class="code">$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)"</p>
             </div>
             <div class="wget">
-                <p class="code">$ bash -c "$(wget https://raw.github.com/ohmybash/oh-my-bash/master/tools/install.sh -O -)"</p>
+                <p class="code">$ bash -c "$(wget https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh -O -)"</p>
             </div>
         </div>
 


### PR DESCRIPTION
Changes `sh` to `bash` in the installation command.

Although the current installation script relies on Bash features, the installation command on the web page instructs the users to use `sh`, which is not necessarily Bash (in BSD, Debian, Ubuntu, etc.). This causes many issues [oh-my-bash #27](https://github.com/ohmybash/oh-my-bash/issues/27), [#43](https://github.com/ohmybash/oh-my-bash/issues/43), [#125](https://github.com/ohmybash/oh-my-bash/issues/125), [#213](https://github.com/ohmybash/oh-my-bash/issues/213), [#253](https://github.com/ohmybash/oh-my-bash/issues/253). README of the main repository has been already fixed by [#167](https://github.com/ohmybash/oh-my-bash/pull/167), [#168](https://github.com/ohmybash/oh-my-bash/pull/168) after the discussion https://github.com/ohmybash/oh-my-bash/issues/27#issuecomment-425317107. However, the web page hasn't yet been updated after almost two years. See also the related comment https://github.com/ohmybash/oh-my-bash/issues/213#issuecomment-822941710.

Fixes #4.