### PR TITLE
Set `lang` attribute for `<html>`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
- [lang attribute](https://dequeuniversity.com/rules/axe/4.7/html-has-lang?application=axeAPI) is good so screen readers don't assume a user-specific language (ensures page is read as English)

Note that an earlier verison of this PR added `rel=noopener`, but that was unecessary since we have `target=_blank` on those `<a>` tags. That seems to be a bug in the a11y linter.